### PR TITLE
Make it bypass the selection UI

### DIFF
--- a/src/Lbaey/Composer/ChromeDriverPlugin.php
+++ b/src/Lbaey/Composer/ChromeDriverPlugin.php
@@ -163,7 +163,10 @@ class ChromeDriverPlugin implements PluginInterface, EventSubscriberInterface
             return;
         }
 
-        $this->platform = $this->io->select('Please select the platform :', $this->getPlatformNames(), $this->platform);
+        $extra = $this->composer->getPackage()->getExtra();
+        if (empty($extra['lbaey/chromedriver']['bypass-select'])) {
+          $this->platform = $this->io->select('Please select the platform :', $this->getPlatformNames(), $this->platform);
+        }
     }
 
     /**


### PR DESCRIPTION
Currently its a little bit annoying to have the selection UI appearing all the time, even well, the library is able to guess the platform actually.

This PR makes this configurable.