### PR TITLE
Fix spec chromedriver version

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ If you want a specific version of chromedriver, use :
 
     "extra": {
         "lbaey/chromedriver": {
-            "chromedriver-version": "2.33"
+            "chromedriver_version": "2.33"
         }
     },


### PR DESCRIPTION
According to the code it's with underscore

`if (empty($extra['lbaey/chromedriver']['chromedriver_version'])`