### PR TITLE
Restore process timeout after execution

### DIFF
--- a/src/Lbaey/Composer/ChromeDriverPlugin.php
+++ b/src/Lbaey/Composer/ChromeDriverPlugin.php
@@ -139,8 +139,15 @@ class ChromeDriverPlugin implements PluginInterface, EventSubscriberInterface
 
         if (file_exists($chromeDriverPath) && is_executable($chromeDriverPath)) {
             $processExecutor = new ProcessExecutor($this->io);
+
+            // Temporarily reduce (?) the timeout to 10 seconds.
+            $originalTimeout = $processExecutor::getTimeout();
             $processExecutor::setTimeout(10);
+
             $processExecutor->execute($chromeDriverPath . ' --version', $output);
+
+            // Restore the timeout.
+            $processExecutor::setTimeout($originalTimeout);
 
             // right version? => nothing to do
             if (strpos($output, 'ChromeDriver ' . $version) === 0) {


### PR DESCRIPTION
Currently, this plugin has the effect of (usually) reducing the process timeout for any process that gets executed after the plugin. This is significantly less than the default 300 seconds, which can have unexpected effects.